### PR TITLE
Saving a record does not clear the cache.

### DIFF
--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -28,13 +28,11 @@ class DataHandlerHook
         if ((isset($params['table'], $params['uid']) || isset($params['uid_page']))
             && RegistryUtility::isEnabled($params['table'])
         ) {
-            $cacheTag = isset($params['uid_page'])
-                ?  PageCacheManager::CACHE_TAG_PREFIX . 'pid_' . $params['uid_page']
-                :  PageCacheManager::CACHE_TAG_PREFIX . $params['table'] . '_' . $params['uid'];
+            $cacheTag = PageCacheManager::CACHE_TAG_PREFIX . $params['table'] . '_' . $params['uid'];
 
             /** @var CacheManager $cacheManager */
             $cacheManager = GeneralUtility::makeInstance(CacheManager::class);
-            $cacheManager->flushCachesInGroupByTag('pages', $cacheTag);
+            $cacheManager->flushCachesByTag($cacheTag);
         }
     }
 }


### PR DESCRIPTION
Saving a record does not clear the cache. In my tests flushCachesByTag is enough to clear all neccessary caches so that tx_fluidpagecache_pid_cache_tag is not neccessary.

Already mentioned some times ago:
https://bitbucket.org/t--3/fluid_page_cache/pull-requests/1