### PR TITLE
Add PHP requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         }
     ],
     "require": {
+        "php": "^7.4 || ^8.0",
         "typo3/cms-core": "^10.4.6 || ^11.5"
     },
     "autoload": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,6 +11,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '2.0.0',
     'constraints' => [
         'depends' => [
+            'php' => '7.4.0-8.0.99',
             'typo3' => '10.4.6-11.5.99'
         ],
         'conflicts' => [],


### PR DESCRIPTION
This change adds explicit PHP-requirements to prevent accidental installations.

Example with PHP 7.3 ("unsupported"):
```
ParseError
syntax error, unexpected 'int' (T_STRING), expecting function (T_FUNCTION) or const (T_CONST)
```