### PR TITLE
Fix unserialize error in getCacheKeyInfo

### DIFF
--- a/Classes/Reports/PageCacheReport.php
+++ b/Classes/Reports/PageCacheReport.php
@@ -185,6 +185,9 @@ class PageCacheReport
     protected function getCacheKeyInfo(AbstractBackend $backend, $keySanitized): ?array
     {
         $info = $backend->get($keySanitized);
+        if ($info === false) {
+            return null;
+        }
         $info = unserialize($info, ['allowed_classes' => false]);
 
         if ($info['page_id'] !== $this->id) {


### PR DESCRIPTION
While my test systems work fine, I can reproduce a 503 error in production `unserialize() expects parameter 1 to be string, bool given`

This happens when cache->get($identifier) returns false because identifier can't be found. While this might be a seldom race condition, it can be handled easily.