### PR TITLE
[BUGFIX] Fix BE module for Redis and SimpleFile cache backends

### DIFF
--- a/Classes/Controller/BackendModuleController.php
+++ b/Classes/Controller/BackendModuleController.php
@@ -10,7 +10,6 @@ use T3\FluidPageCache\Services\PageCacheReport;
 use TYPO3\CMS\Backend\Routing\PreviewUriBuilder;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
-use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Localization\LanguageService;
@@ -19,10 +18,9 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 class BackendModuleController extends ActionController
 {
     public function __construct(
-        private readonly ModuleTemplateFactory $moduleTemplateFactory,
-        private readonly CacheManager $cacheManager,
-        private readonly PageCacheReport $pageCacheReport,
         private readonly IconFactory $iconFactory,
+        private readonly ModuleTemplateFactory $moduleTemplateFactory,
+        private readonly PageCacheReport $pageCacheReport,
     ) {
     }
 
@@ -33,7 +31,7 @@ class BackendModuleController extends ActionController
 
         $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
 
-        $cacheBackendName = $this->pageCacheReport->getPagesCacheBackendName($this->cacheManager);
+        $cacheBackendName = $this->pageCacheReport->getPagesCacheBackendName();
         $method = 'list' . $cacheBackendName . 'Entries';
 
         $previewDataAttributes = null;
@@ -52,7 +50,7 @@ class BackendModuleController extends ActionController
         $moduleTemplate->assign('now', new \DateTime());
         $moduleTemplate->assign('cacheBackendSupported', method_exists($this->pageCacheReport, $method));
         $moduleTemplate->assign('cacheBackendName', $cacheBackendName);
-        $moduleTemplate->assign('cacheBackendNameFull', $this->pageCacheReport->getPagesCacheBackendName($this->cacheManager, false));
+        $moduleTemplate->assign('cacheBackendNameFull', $this->pageCacheReport->getPagesCacheBackendName(false));
 
         $buttonBar = $moduleTemplate->getDocHeaderComponent()->getButtonBar();
 

--- a/Classes/Services/PageCacheReport.php
+++ b/Classes/Services/PageCacheReport.php
@@ -15,11 +15,12 @@ use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-readonly class PageCacheReport
+/** @noinspection PhpClassCanBeReadonlyInspection */
+class PageCacheReport
 {
     public function __construct(
-        private CacheManager $cacheManager,
-        private ConnectionPool $connectionPool,
+        private readonly CacheManager $cacheManager,
+        private readonly ConnectionPool $connectionPool,
     ) {
     }
 


### PR DESCRIPTION
Fixed Exceptions:

```
Uncaught TYPO3 Exception: Too few arguments to function T3\FluidPageCache\Services\PageCacheReport::listSimpleFileBackendEntries(), 1 passed in fluid_page_cache/Classes/Controller/BackendModuleController.php on line 42 and exactly 2 expected

Uncaught TYPO3 Exception: Too few arguments to function T3\FluidPageCache\Services\PageCacheReport::listRedisBackendEntries(), 1 passed in fluid_page_cache/Classes/Controller/BackendModuleController.php on line 42 and exactly 2 expected

Uncaught TYPO3 Exception: T3\FluidPageCache\Services\PageCacheReport::getPagesCacheBackendName(): Argument #1 ($onlyLastPart) must be of type bool, TYPO3\CMS\Core\Cache\CacheManager given, called in fluid_page_cache/Classes/Controller/BackendModuleController.php on line 36

Uncaught TYPO3 Exception: #1476107295: PHP Warning: Undefined array key "page_id" in fluid_page_cache/Classes/Services/PageCacheReport.php line 164
```